### PR TITLE
KAN-23: Added logic to allow for > and < querries

### DIFF
--- a/src/data/repositories/recipeRepository.js
+++ b/src/data/repositories/recipeRepository.js
@@ -31,7 +31,13 @@ const findByFilters = (filters) => {
     const query = {};
     Object.keys(filters).forEach(key => {
         if (filters[key]) {
-            query[key] = filters[key];
+            if(key.endsWith('_lt') || key.endsWith('_gt')){
+                const field = key.slice(0, -3);
+                const operator = key.endsWith('_lt') ? '$lt' : '$gt';
+                query[field] = { [operator]: filters[key] };
+            }
+            else 
+                query[key] = filters[key];
         }
     });
     return Recipe.find(query);


### PR DESCRIPTION
On the filters endpoint you can now use > and < for all numeric fields

- To the field name in the paramaters add `_lt` or `_gt` to the end as follows

`http://localhost:5000/api/recipes?ServingSize_lt=3`

then the code will look for all recipes where ServingSIze<3